### PR TITLE
use meson for libvips and update

### DIFF
--- a/in.cinny.Cinny.yml
+++ b/in.cinny.Cinny.yml
@@ -66,6 +66,7 @@ modules:
         npm_config_cache: /run/build/Cinny/flatpak-node/npm-cache
         npm_config_offline: 'true'
         npm_config_sharp_libvips_local_prebuilds: /run/build/Cinny/flatpak-node/libvips-cache
+        NODE_OPTIONS: --max_old_space_size=4096
     build-commands:
       - for project in . cinny; do npm ci --offline --legacy-peer-deps --prefix=$project;
         done

--- a/in.cinny.Cinny.yml
+++ b/in.cinny.Cinny.yml
@@ -35,8 +35,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/libvips/libvips
-        tag: v8.13.3
-        commit: c76d74be657ce8302f140cefc2b665682c83b023
+        tag: v8.14.2
+        commit: 800b7f20a4f75a72775692bbb4775a17a338bc83
         x-checker-data:
           type: git
           tag-pattern: ^v((?:\d+.)*\d+)$

--- a/in.cinny.Cinny.yml
+++ b/in.cinny.Cinny.yml
@@ -40,6 +40,7 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^v((?:\d+.)*\d+)$
+    buildsystem: meson
 
   - name: Cinny
     sources:


### PR DESCRIPTION
libvips uses the meson build system as the primary one and will drop autotools support with v8.14. So to apply the update to v8.14.2, this move to meson is needed first.

While I'm it, I needed to increase compile-time v8 memory limit to 4 GB due to changes in js-sdk to make it build locally.

supersedes #47, #48