### PR TITLE
update to GNOME 44 platform

### DIFF
--- a/in.cinny.Cinny.yml
+++ b/in.cinny.Cinny.yml
@@ -29,6 +29,52 @@ build-options:
 modules:
   - shared-modules/libappindicator/libappindicator-gtk3-12.10.json
 
+  - name: webkit2gtk-4.0
+    sources:
+      - type: archive
+        url: https://webkitgtk.org/releases/webkitgtk-2.38.6.tar.xz
+        sha256: 1c614c9589389db1a79ea9ba4293bbe8ac3ab0a2234cac700935fae0724ad48b
+        x-checker-data:
+          type: html
+          url: https://webkitgtk.org/releases/
+          version-pattern: <a href="webkitgtk\-(2\.38\.\d+)\.tar\.xz">
+          url-template: https://webkitgtk.org/releases/webkitgtk-$version.tar.xz
+    buildsystem: cmake-ninja
+    config-opts: 
+      - -DPORT=GTK
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DENABLE_DOCUMENTATION=OFF
+      - -DENABLE_GAMEPAD=OFF
+      - -DUSE_SOUP2=ON
+    modules:
+      - shared-modules/libsoup/libsoup-2.4.json
+      - name: bubblewrap
+        sources:
+          - type: archive
+            url: https://github.com/containers/bubblewrap/releases/download/v0.8.0/bubblewrap-0.8.0.tar.xz
+            sha256: 957ad1149db9033db88e988b12bcebe349a445e1efc8a9b59ad2939a113d333a
+            x-checker-data:
+              type: json
+              url: https://api.github.com/repos/containers/bubblewrap/releases/latest
+              tag-query: .tag_name
+              timestamp-query: .published_at
+              version-query: $tag | sub("^v"; "")
+              url-query: '"https://github.com/containers/bubblewrap/releases/download/\($tag)/bubblewrap-\($version).tar.xz"'
+        buildsystem: meson
+      - name: xdg-dbus-proxy
+        sources:
+          - type: archive
+            url: https://github.com/flatpak/xdg-dbus-proxy/releases/download/0.1.4/xdg-dbus-proxy-0.1.4.tar.xz
+            sha256: 1ec0eab53d1e49966d722352bcfd51ac402dce5190baedc749a8541e761670ab
+            x-checker-data:
+              type: json
+              url: https://api.github.com/repos/flatpak/xdg-dbus-proxy/releases/latest
+              tag-query: .tag_name
+              timestamp-query: .published_at
+              version-query: $tag
+              url-query: '"https://github.com/flatpak/xdg-dbus-proxy/releases/download/\($tag)/xdg-dbus-proxy-\($version).tar.xz"'
+        buildsystem: meson
+
   - name: libvips
     cleanup:
       - /*

--- a/in.cinny.Cinny.yml
+++ b/in.cinny.Cinny.yml
@@ -66,6 +66,7 @@ modules:
         npm_config_cache: /run/build/Cinny/flatpak-node/npm-cache
         npm_config_offline: 'true'
         npm_config_sharp_libvips_local_prebuilds: /run/build/Cinny/flatpak-node/libvips-cache
+        NODE_OPTIONS: --max_old_space_size=4096
     build-commands:
       - for project in . cinny; do npm ci --offline --legacy-peer-deps --prefix=$project;
         done

--- a/in.cinny.Cinny.yml
+++ b/in.cinny.Cinny.yml
@@ -1,6 +1,6 @@
 id: in.cinny.Cinny
 runtime: org.gnome.Platform
-runtime-version: '42'
+runtime-version: '44'
 sdk: org.gnome.Sdk
 command: cinny
 rename-icon: cinny

--- a/in.cinny.Cinny.yml
+++ b/in.cinny.Cinny.yml
@@ -35,8 +35,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/libvips/libvips
-        tag: v8.13.3
-        commit: c76d74be657ce8302f140cefc2b665682c83b023
+        tag: v8.14.2
+        commit: 800b7f20a4f75a72775692bbb4775a17a338bc83
         x-checker-data:
           type: git
           tag-pattern: ^v((?:\d+.)*\d+)$

--- a/in.cinny.Cinny.yml
+++ b/in.cinny.Cinny.yml
@@ -40,6 +40,7 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^v((?:\d+.)*\d+)$
+    buildsystem: meson
 
   - name: Cinny
     sources:


### PR DESCRIPTION
As the GNOME 42 platform is end of life, it should be updated to a maintained platform version. And as subsequent versions do not include WebKit2GTK-4.0 and its libsoup2 dependency anymore, it is better to build WebKit for this project.

includes #49 for memory limit problem

supersedes #43 and fixes #42